### PR TITLE
Fixed bug when sending paste before having opened the main PasteNG window

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+# 11.0.5-20241126-1
+* Fixed bug when sending paste before having opened the main PasteNG window.
+
 # 11.0.5-20241121-1
 * Small refactoring of DialogModule.
 * Added option to send a paste from the chat window.

--- a/Modules/Dialog/DialogModule.lua
+++ b/Modules/Dialog/DialogModule.lua
@@ -373,7 +373,7 @@ do
         DialogModule:RefreshPasteCloseButtons()
     end
 
-    local function CreateDialog()
+    function DialogModule:CreateDialog()
         local rightButtonsWidth = 100
         local bottomButtonWidth = 176
         local textBoxRightMargin = rightButtonsWidth + 50
@@ -536,7 +536,7 @@ do
 
     function DialogModule:ShowDialog()
         if DialogModule.PasteDialog == nil then
-            CreateDialog()
+            self:CreateDialog()
         end
 
         DialogModule.PasteDialog:Show()
@@ -569,6 +569,8 @@ function DialogModule:OnInitialize()
     else
         StaticPopup_Show("PASTENG_WARN_ABOUT_PASTE")
     end
+
+    self:CreateDialog()
 
     DialogModule:RegisterChatCommand("pasteng", "HandleChatCommand")
 end


### PR DESCRIPTION
This fixes #29